### PR TITLE
feat: Add test suite + sample tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# If you're using pnpm, we can remove this
+# but it seems everyone is using npm by default...
+pnpm-lock.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ dist-ssr
 *.sln
 *.sw?
 
+# Test coverage
+coverage/
+
 # If you're using pnpm, we can remove this
 # but it seems everyone is using npm by default...
 pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -18,19 +19,24 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
+    "@vitest/coverage-v8": "2.1.8",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.13.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.11.0",
+    "jsdom": "^26.0.0",
     "postcss": "^8.4.49",
     "prettier": "^3.3.3",
     "tailwindcss": "^3.4.14",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.11.0",
-    "vite": "^5.4.10"
+    "vite": "^5.4.10",
+    "vitest": "^2.1.8"
   }
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -7,7 +7,7 @@ const buttonVariants = cva(
 	{
 		variants: {
 			variant: {
-				default: "text-white bg-button hover:outline hover:outline-dashed hover:outline-accent hover:outline-offset-2",
+				default: "text-white bg-button hover:outline-dashed hover:outline-accent hover:outline-offset-2",
 				// add button variants in here as per Figma design
 			},
 			// not the actual sizes yet, feel free to modify these
@@ -25,9 +25,11 @@ const buttonVariants = cva(
 	},
 );
 
-type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & VariantProps<typeof buttonVariants>;
+type ButtonBaseComponent = HTMLElementTagNameMap['button'];
 
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+type ButtonProps = React.ButtonHTMLAttributes<ButtonBaseComponent> & VariantProps<typeof buttonVariants>;
+
+export const Button = React.forwardRef<ButtonBaseComponent, ButtonProps>(
 	({ className, variant, size, ...props }, ref) => {
 		return <button className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
 	},

--- a/tests/components/ui/button.test.tsx
+++ b/tests/components/ui/button.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { screen, render } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { Button } from "../../../src/components/ui/button";
+
+describe("components/ui/button", () => {
+	it("renders a button", () => {
+		render(
+			<Button />
+		);
+
+		const button = screen.getByRole("button");
+		expect(button).toBeInTheDocument();
+	});
+
+	it("renders a text content", () => {
+		render(
+			<Button>
+				test
+			</Button>
+		);
+
+		const button = screen.getByRole("button");
+		expect(button).toHaveTextContent("test");
+	});
+
+	it("renders a class name", () => {
+		render(
+			<Button
+				className="test class"
+			/>
+		);
+
+		const button = screen.getByRole("button");
+		expect(button).toHaveClass("class test");
+	});
+
+	describe("variants/variant", () => {
+		it.each`
+			variant      | className
+			${"default"} | ${"text-white bg-button hover:outline-dashed hover:outline-accent hover:outline-offset-2"} 
+		`("renders a button of $variant variant", ({
+			variant,
+			className
+		}) => {
+			render(
+				<Button
+					variant={variant}
+				/>
+			);
+
+			const button = screen.getByRole("button");
+			expect(button).toHaveClass(className);
+		});
+	});
+
+	describe("variants/size", () => {
+		it.each`
+			size         | className
+			${"default"} | ${"h-10 px-4 py-2"} 
+			${"lg"}      | ${"h-11 rounded-md px-8"} 
+			${"sm"}      | ${"h-9 rounded-md px-3"} 
+			${"icon"}    | ${"h-10 w-10"} 
+		`("renders a button of $size size", ({
+			size,
+			className
+		}) => {
+			render(
+				<Button
+					size={size}
+				/>
+			);
+
+			const button = screen.getByRole("button");
+			expect(button).toHaveClass(className);
+		});
+	});
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,13 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    coverage: {
+      include: [
+        'src/components/**',
+      ],
+    },
+  },
 })


### PR DESCRIPTION
We are using Vitest as our runner as it is already using our Vite config.

Basic tests for the button component are included. The coverage reports are also set up, just run `npm test -- --coverage`.